### PR TITLE
Add Api-Versioning Support.

### DIFF
--- a/src/DotNetUnknown/DotNetUnknown.csproj
+++ b/src/DotNetUnknown/DotNetUnknown.csproj
@@ -13,6 +13,7 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1"/>
         <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0"/>
         <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0"/>
+        <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0"/>
     </ItemGroup>
 
 </Project>

--- a/src/DotNetUnknown/Program.cs
+++ b/src/DotNetUnknown/Program.cs
@@ -1,4 +1,5 @@
-﻿using DotNetUnknown.Exception;
+﻿using Asp.Versioning;
+using DotNetUnknown.Exception;
 using DotNetUnknown.Logging;
 using Serilog;
 using Serilog.Enrichers.Span;
@@ -18,6 +19,12 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
 builder.Services.AddControllers();
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
+
+builder.Services.AddApiVersioning(options =>
+{
+    options.AssumeDefaultVersionWhenUnspecified = false;
+    options.ApiVersionReader = new HeaderApiVersionReader("X-Api-Version");
+}).AddMvc();
 
 builder.Services.AddTransient<LoggingUtils>();
 

--- a/test/DotNetUnknown.Tests/ApiVersioning/ApiVersioningTestController.cs
+++ b/test/DotNetUnknown.Tests/ApiVersioning/ApiVersioningTestController.cs
@@ -1,0 +1,17 @@
+using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DotNetUnknown.Tests.ApiVersioning;
+
+[ApiController]
+[Route("ApiVersioning")]
+public sealed class ApiVersioningTestController : ControllerBase
+{
+    [HttpGet]
+    [Route("v-1-0")]
+    [ApiVersion("1.0")]
+    public IActionResult RequiredVersionOne()
+    {
+        return Ok(new { Title = "version 1.0 data" });
+    }
+}

--- a/test/DotNetUnknown.Tests/ApiVersioning/ApiVersioningTests.cs
+++ b/test/DotNetUnknown.Tests/ApiVersioning/ApiVersioningTests.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System.Net.Http.Json;
+using DotNetUnknown.Tests.Support;
+
+namespace DotNetUnknown.Tests.ApiVersioning;
+
+[TestFixture]
+public class ApiVersioningTests : MvcTestSupport
+{
+    [SetUp]
+    public void OneTimeSetUp()
+    {
+        HttpClient.DefaultRequestHeaders.Remove("X-Api-Version");
+    }
+
+    internal static IEnumerable<TestInfoRecord> RequestProvider
+    {
+        get
+        {
+            yield return new TestInfoRecord("1.0", "version 1.0 data", HttpStatusCode.OK);
+            yield return new TestInfoRecord("1.1", "Unsupported API version", HttpStatusCode.BadRequest);
+            yield return new TestInfoRecord(null, "Unspecified API version", HttpStatusCode.BadRequest);
+        }
+    }
+
+    [TestCaseSource(nameof(RequestProvider))]
+    public async Task TestApiVersioning(TestInfoRecord testInfoRecord)
+    {
+        // When
+        HttpClient.DefaultRequestHeaders.Add("X-Api-Version", testInfoRecord.Version);
+        var responseMessage = await HttpClient.GetAsync("/ApiVersioning/v-1-0");
+        // Then
+        var statusCode = responseMessage.StatusCode;
+        var responseJson = await responseMessage.Content.ReadFromJsonAsync<ResponseRecord>();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(statusCode, Is.EqualTo(testInfoRecord.Status));
+            Assert.That(responseJson?.Title, Is.EqualTo(testInfoRecord.Title));
+        }
+    }
+
+    public sealed record TestInfoRecord(string? Version, string Title, HttpStatusCode Status);
+
+    private record ResponseRecord(string? Type, string Title, HttpStatusCode? Status, string? Detail, string? TraceId);
+}


### PR DESCRIPTION
Closes: #10

By Default, All apis now require [ApiVersion("<1.0>")] attribute.

Looks for Header Api Version choice, it's not that flexible as Spring, where we can define same Route url methods, only version diffs.