### PR TITLE
Add JWT Validation for Authentication/Authorization.

### DIFF
--- a/src/DotNetUnknown/DotNetUnknown.csproj
+++ b/src/DotNetUnknown/DotNetUnknown.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0"/>
         <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0"/>
         <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/src/DotNetUnknown/Program.cs
+++ b/src/DotNetUnknown/Program.cs
@@ -1,6 +1,11 @@
-﻿using Asp.Versioning;
+﻿using System.Text;
+using Asp.Versioning;
 using DotNetUnknown.Exception;
 using DotNetUnknown.Logging;
+using DotNetUnknown.Security;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.IdentityModel.Tokens;
 using Serilog;
 using Serilog.Enrichers.Span;
 
@@ -16,7 +21,7 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
         "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u3}] [{SourceContext}] [{ThreadId}] [{TraceId} - {SpanId}] {Message:lj}{NewLine}{Exception}")
 );
 
-builder.Services.AddControllers();
+builder.Services.AddControllers(options => { options.Filters.Add(new AuthorizeFilter()); });
 builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
 builder.Services.AddProblemDetails();
 
@@ -26,6 +31,34 @@ builder.Services.AddApiVersioning(options =>
     options.ApiVersionReader = new HeaderApiVersionReader("X-Api-Version");
 }).AddMvc();
 
+#region JWT Authentication & Authorization
+
+var jwtSettings = builder.Configuration.GetRequiredSection("JwtSettings");
+var jwtKey = Encoding.ASCII.GetBytes(jwtSettings["Key"] ?? throw new InvalidOperationException());
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+}).AddJwtBearer(options =>
+{
+    options.RequireHttpsMetadata = false; // Set to true in production
+    options.SaveToken = true;
+    options.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true,
+        ValidateAudience = true,
+        ValidateLifetime = true,
+        ValidateIssuerSigningKey = true,
+        ValidIssuer = jwtSettings["Issuer"],
+        ValidAudience = jwtSettings["Audience"],
+        IssuerSigningKey = new SymmetricSecurityKey(jwtKey)
+    };
+});
+builder.Services.AddAuthorization();
+builder.Services.AddSingleton<JwtTokenUtils>();
+
+#endregion
+
 builder.Services.AddTransient<LoggingUtils>();
 
 var app = builder.Build();
@@ -33,7 +66,12 @@ var app = builder.Build();
 app.UseSerilogRequestLogging();
 
 app.UseExceptionHandler();
+
 app.UseRouting();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.MapControllers();
 
 app.Run();

--- a/src/DotNetUnknown/Security/JwtTokenUtils.cs
+++ b/src/DotNetUnknown/Security/JwtTokenUtils.cs
@@ -1,0 +1,42 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace DotNetUnknown.Security;
+
+public sealed class JwtTokenUtils(IConfiguration configuration)
+{
+    /**
+     * generate JWT token for client use.
+     * usually called after a successful login. (in an authorization server)
+     */
+    public string GenerateToken(UserInfo userInfo)
+    {
+        var jwtSettings = configuration.GetRequiredSection("JwtSettings");
+#nullable disable
+        var jwtKey = Encoding.ASCII.GetBytes(jwtSettings["Key"]);
+#nullable enable
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, userInfo.UserId),
+            new(ClaimTypes.Name, userInfo.Username),
+            new(ClaimTypes.Email, userInfo.Email),
+            new("employee_status", userInfo.Status)
+        };
+        claims.AddRange(userInfo.Roles.Select(role => new Claim(ClaimTypes.Role, role)));
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            Expires = DateTime.UtcNow.AddHours(1),
+            Issuer = jwtSettings["Issuer"],
+            Audience = jwtSettings["Audience"],
+            SigningCredentials =
+                new SigningCredentials(new SymmetricSecurityKey(jwtKey), SecurityAlgorithms.HmacSha256Signature)
+        };
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+}

--- a/src/DotNetUnknown/Security/UserInfo.cs
+++ b/src/DotNetUnknown/Security/UserInfo.cs
@@ -1,0 +1,3 @@
+namespace DotNetUnknown.Security;
+
+public record UserInfo(string UserId, string Username, string Email, List<string> Roles, string Status = "Active");

--- a/src/DotNetUnknown/appsettings.json
+++ b/src/DotNetUnknown/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "JwtSettings": {
+    "Key": "TXlTdXBlclNlY3JldEtleUZvcldlYkFwcGxpY2F0aW9uMTIzNDU=",
+    "Issuer": "YourIssuer",
+    "Audience": "YourAudience"
+  }
 }

--- a/test/DotNetUnknown.Tests/Security/SecurityTestController.cs
+++ b/test/DotNetUnknown.Tests/Security/SecurityTestController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DotNetUnknown.Tests.Security;
+
+[ApiController]
+[Route("security")]
+public sealed class SecurityTestController : ControllerBase
+{
+    [HttpGet]
+    [Route("admin")]
+    [Authorize(Roles = "Admin")]
+    public IActionResult AdminData()
+    {
+        return Ok("this is admin user data");
+    }
+}

--- a/test/DotNetUnknown.Tests/Security/SecurityTests.cs
+++ b/test/DotNetUnknown.Tests/Security/SecurityTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using System.Net.Http.Headers;
+using DotNetUnknown.Tests.Support;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace DotNetUnknown.Tests.Security;
+
+[TestFixture]
+internal sealed class SecurityTests : MvcTestSupport
+{
+    [Test]
+    public async Task TestWithoutJwtToken()
+    {
+        // Given
+        HttpClient.DefaultRequestHeaders.Authorization = null;
+        // When
+        var response = await HttpClient.GetAsync("security/admin");
+        // Then
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+    }
+
+    [Test]
+    public async Task TestWithNormalJwtToken_Forbidden()
+    {
+        // Given
+        var jwtTokenTestSupport = GetRequiredService<JwtTokenTestSupport>();
+        var normalUserToken = jwtTokenTestSupport.NormalUserToken;
+        HttpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme, normalUserToken);
+        // When
+        var response = await HttpClient.GetAsync("security/admin");
+        // Then
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Forbidden));
+    }
+
+
+    [Test]
+    public async Task TestWithAdminJwtToken_Ok()
+    {
+        // Given
+        var jwtTokenTestSupport = GetRequiredService<JwtTokenTestSupport>();
+        var adminUserToken = jwtTokenTestSupport.AdminUserToken;
+        HttpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme, adminUserToken);
+        // When
+        var response = await HttpClient.GetAsync("security/admin");
+        // Then
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.That(content, Is.EqualTo("this is admin user data"));
+    }
+}

--- a/test/DotNetUnknown.Tests/Support/JwtTokenTestSupport.cs
+++ b/test/DotNetUnknown.Tests/Support/JwtTokenTestSupport.cs
@@ -1,0 +1,13 @@
+using DotNetUnknown.Security;
+
+namespace DotNetUnknown.Tests.Support;
+
+public sealed class JwtTokenTestSupport(JwtTokenUtils jwtTokenUtils)
+{
+    private static readonly UserInfo Alice = new("user-id-123", "alice", "alice@example.com", ["User"]);
+
+    private static readonly UserInfo Bob = new("user-id-456", "bob", "bob@example.com", ["User", "Admin"]);
+
+    public string NormalUserToken => jwtTokenUtils.GenerateToken(Alice);
+    public string AdminUserToken => jwtTokenUtils.GenerateToken(Bob);
+}

--- a/test/DotNetUnknown.Tests/Support/MvcTestSupport.cs
+++ b/test/DotNetUnknown.Tests/Support/MvcTestSupport.cs
@@ -1,4 +1,6 @@
+using System.Net.Http.Headers;
 using System.Reflection;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,6 +17,12 @@ public class MvcTestSupport
     {
         _webAppFactory = new WebAppFactory();
         HttpClient = _webAppFactory.CreateClient();
+        // add a api version before each request
+        HttpClient.DefaultRequestHeaders.Add("X-Api-Version", "1.0");
+        // add a jwt token before each request
+        var jwtTokenUtils = GetRequiredService<JwtTokenTestSupport>();
+        HttpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme, jwtTokenUtils.NormalUserToken);
     }
 
     [OneTimeTearDown]
@@ -38,6 +46,7 @@ internal sealed class WebAppFactory : WebApplicationFactory<Program>
         {
             services.AddControllers()
                 .AddApplicationPart(Assembly.GetExecutingAssembly());
+            services.AddSingleton<JwtTokenTestSupport>();
         });
     }
 }


### PR DESCRIPTION
And, Apply to all controller endpoints.

Also, provide a GenerateToken method (typically should be placed in a authorization server) for better testing use.

Modify WebTestSupport to add a jwt token for HttpClient before sending each requests.

Security Endpoints Integration tests.

Closes: #13