### PR TITLE
Add Transaction Rollback case

### DIFF
--- a/src/DotNetUnknown/Api.http
+++ b/src/DotNetUnknown/Api.http
@@ -23,7 +23,8 @@ X-Api-Version: 1.0
 {
   "MasterAccNum": 10000,
   "SubAccNum": 10001,
-  "Amount": 60
+  "Amount": 60,
+  "FlagException": true
 }
 
 ### accountBalance

--- a/src/DotNetUnknown/DbConfig/AppDbContext.cs
+++ b/src/DotNetUnknown/DbConfig/AppDbContext.cs
@@ -7,4 +7,5 @@ public class AppDbContext(DbContextOptions options) : DbContext(options)
 {
     public DbSet<MasterAccount> MasterAccount { get; set; } = null!;
     public DbSet<SubAccount> SubAccount { get; set; } = null!;
+    public DbSet<AuditTrail> AuditTrail { get; set; } = null!;
 }

--- a/src/DotNetUnknown/Transaction/AuditService.cs
+++ b/src/DotNetUnknown/Transaction/AuditService.cs
@@ -1,0 +1,45 @@
+using DotNetUnknown.DbConfig;
+using DotNetUnknown.Transaction.Entity;
+using Microsoft.EntityFrameworkCore;
+
+namespace DotNetUnknown.Transaction;
+
+public class AuditService(AppDbContext dbCtx)
+{
+    public void ClearAll()
+    {
+        dbCtx.AuditTrail.ExecuteDelete();
+        dbCtx.SaveChanges();
+    }
+
+    public void InsertAudit(string maker, string checker, string comment)
+    {
+        var auditTrail = new AuditTrail() { Maker = maker, Comment = comment, Checker = checker };
+        dbCtx.AuditTrail.Add(auditTrail);
+        dbCtx.SaveChanges();
+    }
+
+    public void InsertAuditInTx(string maker, string checker, string comment)
+    {
+        // if this inner transaction be called inside an outer transaction, will throw below exception:
+        // The connection is already in a transaction and cannot participate in another transaction.
+        using var transaction = dbCtx.Database.BeginTransaction();
+        try
+        {
+            var auditTrail = new AuditTrail() { Maker = maker, Comment = comment, Checker = checker };
+            dbCtx.AuditTrail.Add(auditTrail);
+            dbCtx.SaveChanges();
+            transaction.Commit();
+        }
+        catch (System.Exception)
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+
+    public List<AuditTrail> GetAuditTrail()
+    {
+        return dbCtx.AuditTrail.ToList();
+    }
+}

--- a/src/DotNetUnknown/Transaction/Entity/AuditTrail.cs
+++ b/src/DotNetUnknown/Transaction/Entity/AuditTrail.cs
@@ -1,0 +1,9 @@
+namespace DotNetUnknown.Transaction.Entity;
+
+public class AuditTrail
+{
+    public int Id { get; init; }
+    public required string Maker { get; init; }
+    public required string Checker { get; init; }
+    public required string Comment { get; init; }
+}

--- a/src/DotNetUnknown/Transaction/Model/AccountBalanceResp.cs
+++ b/src/DotNetUnknown/Transaction/Model/AccountBalanceResp.cs
@@ -1,0 +1,10 @@
+using DotNetUnknown.Transaction.Entity;
+
+namespace DotNetUnknown.Transaction.Model;
+
+public struct AccountBalanceResp
+{
+    public decimal MasterAccBalance { get; init; }
+    public decimal SubAccBalance { get; init; }
+    public List<AuditTrail> AuditTrail { get; init; }
+}

--- a/src/DotNetUnknown/Transaction/Model/MoneyTransferReq.cs
+++ b/src/DotNetUnknown/Transaction/Model/MoneyTransferReq.cs
@@ -5,4 +5,5 @@ public class MoneyTransferReq
     public int MasterAccNum { get; set; }
     public int SubAccNum { get; set; }
     public decimal Amount { get; set; }
+    public bool FlagException { get; set; }
 }

--- a/src/DotNetUnknown/Transaction/TransactionController.cs
+++ b/src/DotNetUnknown/Transaction/TransactionController.cs
@@ -5,13 +5,14 @@ namespace DotNetUnknown.Transaction;
 
 [Route("transaction")]
 [ApiController]
-public class TransactionController(TransactionService transactionService) : ControllerBase
+public class TransactionController(TransactionService transactionService, AuditService auditService) : ControllerBase
 {
     [HttpPost]
     [Route("resetAccount")]
     public ActionResult<string> ResetAccount(ResetAccountReq resetAccountReq)
     {
         transactionService.ResetAccount(resetAccountReq.MasterAccNum, resetAccountReq.SubAccNum);
+        auditService.ClearAll();
         return Ok();
     }
 
@@ -25,10 +26,15 @@ public class TransactionController(TransactionService transactionService) : Cont
 
     [HttpPost]
     [Route("accountBalance")]
-    public ActionResult<string> AccountBalance(AccountBalanceReq accountBalanceReq)
+    public ActionResult<AccountBalanceResp> AccountBalance(AccountBalanceReq accountBalanceReq)
     {
         var (masterAccBalance, subAccBalance) =
             transactionService.FindBalance(accountBalanceReq.MasterAccNum, accountBalanceReq.SubAccNum);
-        return Ok("masterAccBalance:" + masterAccBalance + ", subAccBalance:" + subAccBalance);
+        var accountBalanceResp = new AccountBalanceResp
+        {
+            MasterAccBalance = masterAccBalance, SubAccBalance = subAccBalance,
+            AuditTrail = auditService.GetAuditTrail()
+        };
+        return Ok(accountBalanceResp);
     }
 }

--- a/src/DotNetUnknown/Transaction/TransactionExtension.cs
+++ b/src/DotNetUnknown/Transaction/TransactionExtension.cs
@@ -7,6 +7,7 @@ public static class TransactionExtension
         public void RegisterTransactionServices()
         {
             serviceCollection.AddScoped<TransactionService>();
+            serviceCollection.AddScoped<AuditService>();
         }
     }
 }

--- a/test/DotNetUnknown.Tests/Support/BaseTestSupport.cs
+++ b/test/DotNetUnknown.Tests/Support/BaseTestSupport.cs
@@ -1,20 +1,27 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DotNetUnknown.Tests.Support;
 
-public class BaseTestSupport
+public abstract class BaseTestSupport
 {
     protected WebAppFactory WebAppFactory;
 
     [OneTimeSetUp]
     public void BaseSetUp()
     {
-        WebAppFactory = new WebAppFactory(ConfigureServicesAction());
+        WebAppFactory = new WebAppFactory(ConfigureServicesAction(), ConfigureTestServicesAction());
     }
 
+
     protected virtual Action<IServiceCollection>? ConfigureServicesAction()
+    {
+        return null;
+    }
+
+    protected virtual Action<IServiceCollection>? ConfigureTestServicesAction()
     {
         return null;
     }
@@ -31,13 +38,20 @@ public class BaseTestSupport
     }
 }
 
-public class WebAppFactory(Action<IServiceCollection>? configureServices) : WebApplicationFactory<Program>
+public class WebAppFactory(
+    Action<IServiceCollection>? configureServices,
+    Action<IServiceCollection>? configureTestServices) : WebApplicationFactory<Program>
 {
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         if (configureServices != null)
         {
             builder.ConfigureServices(configureServices);
+        }
+
+        if (configureTestServices != null)
+        {
+            builder.ConfigureTestServices(configureTestServices);
         }
     }
 }

--- a/test/DotNetUnknown.Tests/Support/DbTestSupport.cs
+++ b/test/DotNetUnknown.Tests/Support/DbTestSupport.cs
@@ -1,0 +1,38 @@
+using DotNetUnknown.DbConfig;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace DotNetUnknown.Tests.Support;
+
+public abstract class DbTestSupport : BaseTestSupport
+{
+    public required SqliteConnection SqliteConnection;
+
+    protected override Action<IServiceCollection> ConfigureTestServicesAction()
+    {
+        return services =>
+        {
+            // Remove Application's DbContext
+            services.RemoveAll<DbContextOptions<AppDbContext>>();
+            services.RemoveAll<AppDbContext>();
+            // Register a new DbContext for integration testing
+            SqliteConnection = new SqliteConnection("DataSource=:memory:");
+            SqliteConnection.Open(); // need to keep conn open for in-memory db
+            services.AddDbContext<AppDbContext>(options => options.UseSqlite(SqliteConnection));
+        };
+    }
+
+    [OneTimeSetUp]
+    public void DbSetup()
+    {
+    }
+
+    [OneTimeTearDown]
+    public void DbTeardown()
+    {
+        SqliteConnection.Close();
+        SqliteConnection.Dispose();
+    }
+}

--- a/test/DotNetUnknown.Tests/Support/MvcTestSupport.cs
+++ b/test/DotNetUnknown.Tests/Support/MvcTestSupport.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace DotNetUnknown.Tests.Support;
 
-public class MvcTestSupport : BaseTestSupport
+public abstract class MvcTestSupport : BaseTestSupport
 {
     protected HttpClient HttpClient;
 

--- a/test/DotNetUnknown.Tests/Transaction/TransactionServiceTests.cs
+++ b/test/DotNetUnknown.Tests/Transaction/TransactionServiceTests.cs
@@ -1,0 +1,54 @@
+using DotNetUnknown.Tests.Support;
+using DotNetUnknown.Transaction;
+using DotNetUnknown.Transaction.Model;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DotNetUnknown.Tests.Transaction;
+
+[TestFixture]
+public class TransactionServiceTests : DbTestSupport
+{
+    private const int MasterAccNum = 10000;
+    private const int SubAccNum = 10001;
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public void TestMoneyTransfer(bool hasException)
+    {
+        // Data Reset
+        using var scope = WebAppFactory.Services.CreateScope();
+        var transactionService = scope.ServiceProvider.GetRequiredService<TransactionService>();
+        var auditService = scope.ServiceProvider.GetRequiredService<AuditService>();
+        transactionService.ResetAccount(MasterAccNum, SubAccNum);
+        auditService.ClearAll();
+        // Given
+        var transferReq = new MoneyTransferReq
+            { Amount = 60, MasterAccNum = MasterAccNum, SubAccNum = SubAccNum, FlagException = hasException };
+        // When
+        try
+        {
+            transactionService.MoneyTransfer(transferReq);
+        }
+        catch (System.Exception)
+        {
+            // ignored
+        }
+
+        // Then (use a new scope)
+        using var scope2 = WebAppFactory.Services.CreateScope();
+        var transactionService2 = scope2.ServiceProvider.GetRequiredService<TransactionService>();
+        var auditService2 = scope2.ServiceProvider.GetRequiredService<AuditService>();
+        var (masterAccBalance, subAccBalance) =
+            transactionService2.FindBalance(transferReq.MasterAccNum, transferReq.SubAccNum);
+        var auditTrails = auditService2.GetAuditTrail();
+        var expectedMasterAccBalance = hasException ? 100 : 40;
+        var expectedSubAccBalance = hasException ? 0 : 60;
+        var expectedAuditTrailsCnt = hasException ? 0 : 2;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(masterAccBalance, Is.EqualTo(expectedMasterAccBalance));
+            Assert.That(subAccBalance, Is.EqualTo(expectedSubAccBalance));
+            Assert.That(auditTrails, Has.Count.EqualTo(expectedAuditTrailsCnt));
+        }
+    }
+}


### PR DESCRIPTION
- use explict dbCtx.Database.BeginTransaction() instead of new TransactionScope(), due to sqlite limitation.
- failed to try inner transaction case, may be the inner tx need to be wrapped as a new scope to be called.
- add DbTestSupport base class for using memory db integration test.

Closes: #24