### PR TITLE
Add Health Check Usage.

### DIFF
--- a/src/DotNetUnknown/DotNetUnknown.csproj
+++ b/src/DotNetUnknown/DotNetUnknown.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.1"/>
         <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0"/>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0"/>
         <PackageReference Include="Serilog.AspNetCore" Version="10.0.0"/>

--- a/src/DotNetUnknown/HealthCheck/HealthCheckExtension.cs
+++ b/src/DotNetUnknown/HealthCheck/HealthCheckExtension.cs
@@ -1,0 +1,57 @@
+using DotNetUnknown.DbConfig;
+using DotNetUnknown.Json;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace DotNetUnknown.HealthCheck;
+
+public static class HealthCheckExtension
+{
+    public static void AddHealthCheck(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddHostedService<StartupBackgroundService>()
+            .AddSingleton<StartupHealthCheck>();
+
+        services.AddHealthChecks()
+            .AddCheck<StartupHealthCheck>(name: "Startup", tags: ["ready"])
+            .AddDbContextCheck<AppDbContext>(name: "Postgres", tags: ["db"]);
+
+        if (configuration.GetValue<bool>(key: "HealthCheck:EnablePublisher"))
+        {
+            services.AddSingleton<IHealthCheckPublisher, HealthCheckPublisher>();
+
+            services.Configure<HealthCheckPublisherOptions>(options =>
+            {
+                options.Delay = TimeSpan.FromSeconds(2);
+                options.Period = TimeSpan.FromSeconds(60);
+            });
+        }
+    }
+
+    public static void UseHealthCheck(this WebApplication app)
+    {
+        app.MapHealthChecks(pattern: "/health", new HealthCheckOptions
+        {
+            ResponseWriter = (context, result) =>
+            {
+                context.Response.ContentType = "application/json";
+                var response = new HealthCheckResponse(
+                    Status: result.Status.ToString(),
+                    Results: result.Entries.ToDictionary(
+                        pair => pair.Key,
+                        pair => new HealthCheckEntry(
+                            Status: pair.Value.Status.ToString(),
+                            Description: pair.Value.Description,
+                            DurationMilliseconds: (long)pair.Value.Duration.TotalMilliseconds,
+                            Exception: pair.Value.Exception?.Message,
+                            // Safely convert heterogeneous objects to strings for JSON output
+                            Data: pair.Value.Data.ToDictionary(kv => kv.Key, kv => kv.Value?.ToString())
+                        )
+                    )
+                );
+
+                return context.Response.WriteAsync(JsonUtils.Serialize(response));
+            }
+        });
+    }
+}

--- a/src/DotNetUnknown/HealthCheck/HealthCheckPublisher.cs
+++ b/src/DotNetUnknown/HealthCheck/HealthCheckPublisher.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace DotNetUnknown.HealthCheck;
+
+public sealed class HealthCheckPublisher(ILogger<HealthCheckPublisher> logger, IWebHostEnvironment environment)
+    : IHealthCheckPublisher
+{
+    public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+    {
+        var logLevel = report.Status == HealthStatus.Healthy ? LogLevel.Information : LogLevel.Error;
+
+        logger.Log(
+            logLevel,
+            message: "{HealthStatus} {AppName} {Timestamp} {EnvironmentName} Readiness Probe Status: {@Report}",
+            report.Status,
+            environment.ApplicationName,
+            DateTime.Now,
+            environment.EnvironmentName,
+            report);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/DotNetUnknown/HealthCheck/HealthCheckResponse.cs
+++ b/src/DotNetUnknown/HealthCheck/HealthCheckResponse.cs
@@ -1,0 +1,14 @@
+namespace DotNetUnknown.HealthCheck;
+
+public sealed record HealthCheckResponse(
+    string Status,
+    IReadOnlyDictionary<string, HealthCheckEntry> Results
+);
+
+public sealed record HealthCheckEntry(
+    string Status,
+    string? Description,
+    long DurationMilliseconds,
+    string? Exception,
+    IReadOnlyDictionary<string, string?> Data
+);

--- a/src/DotNetUnknown/HealthCheck/StartupHealthCheck.cs
+++ b/src/DotNetUnknown/HealthCheck/StartupHealthCheck.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace DotNetUnknown.HealthCheck;
+
+public sealed class StartupHealthCheck : IHealthCheck
+{
+    private volatile bool _isReady;
+
+    public bool StartupCompleted
+    {
+        get => _isReady;
+        set => _isReady = value;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (StartupCompleted)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy(description: "The startup task has completed."));
+        }
+
+        return Task.FromResult(HealthCheckResult.Unhealthy(description: "That startup task is still running."));
+    }
+}
+
+public class StartupBackgroundService(StartupHealthCheck startupHealthCheck) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Simulate the effect of a long-running task.
+        await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+
+        startupHealthCheck.StartupCompleted = true;
+    }
+}

--- a/src/DotNetUnknown/Program.cs
+++ b/src/DotNetUnknown/Program.cs
@@ -2,6 +2,7 @@
 using Asp.Versioning;
 using DotNetUnknown.DbConfig;
 using DotNetUnknown.Exception;
+using DotNetUnknown.HealthCheck;
 using DotNetUnknown.Http;
 using DotNetUnknown.Logging;
 using DotNetUnknown.Security;
@@ -24,6 +25,7 @@ services.AddControllers(options => { options.Filters.Add(new AuthorizeFilter());
 services.AddExceptionHandler<GlobalExceptionHandler>();
 services.AddProblemDetails();
 
+services.AddHealthCheck(builder.Configuration);
 services.AddApiVersioning(options =>
 {
     options.AssumeDefaultVersionWhenUnspecified = false;
@@ -75,6 +77,8 @@ var app = builder.Build();
 app.UseSerilogRequestLogging();
 
 app.UseExceptionHandler();
+
+app.UseHealthCheck();
 
 app.UseRouting();
 

--- a/src/DotNetUnknown/appsettings.json
+++ b/src/DotNetUnknown/appsettings.json
@@ -23,5 +23,8 @@
     "Key": "TXlTdXBlclNlY3JldEtleUZvcldlYkFwcGxpY2F0aW9uMTIzNDU=",
     "Issuer": "YourIssuer",
     "Audience": "YourAudience"
+  },
+  "HealthCheck": {
+    "EnablePublisher": false
   }
 }


### PR DESCRIPTION
- Add a Startup health check which simulate a long-running task.
- Add DBContext health check using Microsoft Diagnostics Extension
- Add a HealthCheckPublisher which pull the health status every 60s.
- Customize the `/health` endpoint response structure.

Closes: #42